### PR TITLE
Openssl verification mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ You can add some option arguments to `EMail.send`.
 
     Try to use `STARTTLS` command to send email with TLS encryption.
 
+- `openssl_verification_mode : String` (Default: `nil`)
+
+    You can select OpenSSL verification mode. Valid values are `"client_once", "fail_if_no_peer_cert", "none", "peer"`
+    For Example use `"none"` to start `tls` connection with mail server which uses self-signed certificates.
+
 - `auth : Tuple(String, String)` (Default: None)
 
     Set login id and password to use `AUTH PLAIN` or `AUTH LOGIN` command: e.g. `{"login_id", "password"}`.

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ You can add some option arguments to `EMail.send`.
 
 - `openssl_verification_mode : String` (Default: `nil`)
 
-    You can select OpenSSL verification mode. Valid values are `client_once`, `fail_if_no_peer_cert`, `none` and `peer`.
-    For Example use `"none"` to start `tls` connection with mail server which uses self-signed certificates.
+    You can select OpenSSL verification mode. Its value is `OpenSSL::SSL::VerifyMode` enum. See (OpenSSL::SSL::VerifyMode)[https://crystal-lang.org/api/0.26.1/OpenSSL/SSL/VerifyMode.html].
+    For Example use `:none` to start `tls` connection with mail server which uses self-signed certificates.
 
 - `auth : Tuple(String, String)` (Default: None)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can add some option arguments to `EMail.send`.
 
 - `openssl_verification_mode : String` (Default: `nil`)
 
-    You can select OpenSSL verification mode. Its value is `OpenSSL::SSL::VerifyMode` enum. See (OpenSSL::SSL::VerifyMode)[https://crystal-lang.org/api/0.26.1/OpenSSL/SSL/VerifyMode.html].
+    You can select OpenSSL verification mode. Its value is `OpenSSL::SSL::VerifyMode` enum. See [OpenSSL::SSL::VerifyMode](https://crystal-lang.org/api/0.26.1/OpenSSL/SSL/VerifyMode.html).
     For Example use `:none` to start `tls` connection with mail server which uses self-signed certificates.
 
 - `auth : Tuple(String, String)` (Default: None)

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ You can add some option arguments to `EMail.send`.
 
     Try to use `STARTTLS` command to send email with TLS encryption.
 
-- `openssl_verification_mode : String` (Default: `nil`)
+- `openssl_verification_mode : OpenSSL::SSL::VerifyMode` (Default: `nil`)
 
-    You can select OpenSSL verification mode. Its value is `OpenSSL::SSL::VerifyMode` enum. See [OpenSSL::SSL::VerifyMode](https://crystal-lang.org/api/0.26.1/OpenSSL/SSL/VerifyMode.html).
+    You can select OpenSSL verification mode. See [OpenSSL::SSL::VerifyMode](https://crystal-lang.org/api/0.26.1/OpenSSL/SSL/VerifyMode.html).
     For Example use `:none` to start `tls` connection with mail server which uses self-signed certificates.
 
 - `auth : Tuple(String, String)` (Default: None)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can add some option arguments to `EMail.send`.
 
     Try to use `STARTTLS` command to send email with TLS encryption.
 
-- `openssl_verification_mode : OpenSSL::SSL::VerifyMode` (Default: `nil`)
+- `openssl_verification_mode : OpenSSL::SSL::VerifyMode` (Default: `:peer`)
 
     You can select OpenSSL verification mode. See [OpenSSL::SSL::VerifyMode](https://crystal-lang.org/api/0.26.1/OpenSSL/SSL/VerifyMode.html).
     For Example use `:none` to start `tls` connection with mail server which uses self-signed certificates.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can add some option arguments to `EMail.send`.
 
 - `openssl_verification_mode : String` (Default: `nil`)
 
-    You can select OpenSSL verification mode. Valid values are `"client_once", "fail_if_no_peer_cert", "none", "peer"`
+    You can select OpenSSL verification mode. Valid values are `client_once`, `fail_if_no_peer_cert`, `none` and `peer`.
     For Example use `"none"` to start `tls` connection with mail server which uses self-signed certificates.
 
 - `auth : Tuple(String, String)` (Default: None)

--- a/src/email/client.cr
+++ b/src/email/client.cr
@@ -43,14 +43,14 @@ class EMail::Client
   @on_failed : EMail::Client::OnFailedProc?
   @on_fatal_error : EMail::Client::OnFatalErrorProc?
   @use_tls : Bool
-  @openssl_verify_mode : OpenSSL::SSL::VerifyMode?
+  @openssl_verify_mode : OpenSSL::SSL::VerifyMode
   @auth : Tuple(String, String)?
   @esmtp_commands = Hash(String, Array(String)).new { |h, k| h[k] = Array(String).new }
 
   # Creates smtp client object.
   def initialize(@host, @port = EMail::DEFAULT_SMTP_PORT, *,
                  client_name @name = EMail::Client::DEFAULT_NAME, @helo_domain = nil,
-                 @on_failed = nil, @on_fatal_error = nil, @openssl_verify_mode = nil,
+                 @on_failed = nil, @on_fatal_error = nil, @openssl_verify_mode = :peer,
                  @use_tls = false, @auth = nil, logger : Logger? = nil)
     raise EMail::Error::ClientError.new("Invalid client name \"#{@name}\"") if @name.empty? || @name =~ /[^\w]/
     if helo_domain = @helo_domain
@@ -67,7 +67,7 @@ class EMail::Client
   def initialize(server_host : String, server_port : Int32 = EMail::DEFAULT_SMTP_PORT, *,
                  client_name : String = EMail::Client::DEFAULT_NAME, helo_domain : String? = nil,
                  on_failed : EMail::Client::OnFailedProc? = nil, on_fatal_error : EMail::Client::OnFatalErrorProc? = nil,
-                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : OpenSSL::SSL::VerifyMode? = nil,
+                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : OpenSSL::SSL::VerifyMode = :peer,
                  log_io : IO? = nil, log_progname : String? = nil,
                  log_formatter : Logger::Formatter? = nil, log_level : Logger::Severity? = nil)
     logger = EMail::Client.create_default_logger(log_io, log_progname, log_formatter, log_level)
@@ -198,9 +198,7 @@ class EMail::Client
           false
         {% else %}
           tls_context = OpenSSL::SSL::Context::Client.new
-          if !@openssl_verify_mode.nil?
-            tls_context.verify_mode = @openssl_verify_mode.not_nil!
-          end
+          tls_context.verify_mode = @openssl_verify_mode
           tls_socket = OpenSSL::SSL::Socket::Client.new(@socket.as(TCPSocket), tls_context, sync_close: true, hostname: @host)
           tls_socket.sync = false
           log_info("Start TLS session")

--- a/src/email/client.cr
+++ b/src/email/client.cr
@@ -11,7 +11,13 @@ class EMail::Client
   DEFAULT_NAME = "EMail_Client"
 
   # :nodoc:
-  DOMAIN_FORMAT = /\A[a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`^{\|\}\~]+(\.[a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`^{\|\}\~]+)+\z/
+  DOMAIN_FORMAT              = /\A[a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`^{\|\}\~]+(\.[a-zA-Z0-9\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`^{\|\}\~]+)+\z/
+  OPENSSL_VERIFICATION_MODES = {
+    "client_once"          => OpenSSL::SSL::VerifyMode::CLIENT_ONCE,
+    "fail_if_no_peer_cert" => OpenSSL::SSL::VerifyMode::FAIL_IF_NO_PEER_CERT,
+    "none"                 => OpenSSL::SSL::VerifyMode::NONE,
+    "peer"                 => OpenSSL::SSL::VerifyMode::PEER,
+  }
 
   def self.create_default_logger(log_io : IO? = nil,
                                  log_progname : String? = nil,
@@ -43,13 +49,14 @@ class EMail::Client
   @on_failed : EMail::Client::OnFailedProc?
   @on_fatal_error : EMail::Client::OnFatalErrorProc?
   @use_tls : Bool
+  @openssl_verify_mode : String?
   @auth : Tuple(String, String)?
   @esmtp_commands = Hash(String, Array(String)).new { |h, k| h[k] = Array(String).new }
 
   # Creates smtp client object.
   def initialize(@host, @port = EMail::DEFAULT_SMTP_PORT, *,
                  client_name @name = EMail::Client::DEFAULT_NAME, @helo_domain = nil,
-                 @on_failed = nil, @on_fatal_error = nil,
+                 @on_failed = nil, @on_fatal_error = nil, @openssl_verify_mode = nil,
                  @use_tls = false, @auth = nil, logger : Logger? = nil)
     raise EMail::Error::ClientError.new("Invalid client name \"#{@name}\"") if @name.empty? || @name =~ /[^\w]/
     if helo_domain = @helo_domain
@@ -66,7 +73,7 @@ class EMail::Client
   def initialize(server_host : String, server_port : Int32 = EMail::DEFAULT_SMTP_PORT, *,
                  client_name : String = EMail::Client::DEFAULT_NAME, helo_domain : String? = nil,
                  on_failed : EMail::Client::OnFailedProc? = nil, on_fatal_error : EMail::Client::OnFatalErrorProc? = nil,
-                 use_tls : Bool = false, auth : Tuple(String, String)? = nil,
+                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : String? = nil,
                  log_io : IO? = nil, log_progname : String? = nil,
                  log_formatter : Logger::Formatter? = nil, log_level : Logger::Severity? = nil)
     logger = EMail::Client.create_default_logger(log_io, log_progname, log_formatter, log_level)
@@ -196,7 +203,13 @@ class EMail::Client
           log_error("TLS is disabled because `-D without_openssl` was passed at compile time")
           false
         {% else %}
-          tls_socket = OpenSSL::SSL::Socket::Client.new(@socket.as(TCPSocket), sync_close: true, hostname: @host)
+          tls_context = OpenSSL::SSL::Context::Client.new
+          if !@openssl_verify_mode.nil? && OPENSSL_VERIFICATION_MODES.keys.index(@openssl_verify_mode.to_s)
+            tls_context.verify_mode = OPENSSL_VERIFICATION_MODES[@openssl_verify_mode.to_s]
+          else
+            log_error("Not a valid openssl_verification_mode. Allowed modes: #{OPENSSL_VERIFICATION_MODES.keys}")
+          end
+          tls_socket = OpenSSL::SSL::Socket::Client.new(@socket.as(TCPSocket), tls_context, sync_close: true, hostname: @host)
           tls_socket.sync = false
           log_info("Start TLS session")
           @socket = tls_socket

--- a/src/email/sender.cr
+++ b/src/email/sender.cr
@@ -10,7 +10,7 @@ class EMail::Sender
   @on_failed : EMail::Client::OnFailedProc?
   @on_fatal_error : EMail::Client::OnFatalErrorProc?
   @use_tls : Bool
-  @openssl_verify_mode : String?
+  @openssl_verify_mode : OpenSSL::SSL::VerifyMode?
   @auth : Tuple(String, String)?
   @logger : Logger
   @finished : Bool = false
@@ -28,7 +28,7 @@ class EMail::Sender
   def initialize(server_host : String, server_port : Int32 = EMail::DEFAULT_SMTP_PORT, *,
                  client_name : String = EMail::Client::DEFAULT_NAME, helo_domain : String? = nil,
                  on_failed : EMail::Client::OnFailedProc? = nil, on_fatal_error : EMail::Client::OnFatalErrorProc? = nil,
-                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : String? = nil,
+                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : OpenSSL::SSL::VerifyMode? = nil,
                  log_io : IO? = nil, log_progname : String? = nil,
                  log_formatter : Logger::Formatter? = nil, log_level : Logger::Severity? = nil)
     logger = EMail::Client.create_default_logger(log_io, log_progname, log_formatter, log_level)

--- a/src/email/sender.cr
+++ b/src/email/sender.cr
@@ -10,7 +10,7 @@ class EMail::Sender
   @on_failed : EMail::Client::OnFailedProc?
   @on_fatal_error : EMail::Client::OnFatalErrorProc?
   @use_tls : Bool
-  @openssl_verify_mode : OpenSSL::SSL::VerifyMode?
+  @openssl_verify_mode : OpenSSL::SSL::VerifyMode
   @auth : Tuple(String, String)?
   @logger : Logger
   @finished : Bool = false
@@ -20,7 +20,7 @@ class EMail::Sender
 
   def initialize(@server_host, @server_port = EMail::DEFAULT_SMTP_PORT, *,
                  @client_name = EMail::Client::DEFAULT_NAME, @helo_domain = nil,
-                 @use_tls = false, @auth = nil, @openssl_verify_mode = nil,
+                 @use_tls = false, @auth = nil, @openssl_verify_mode = :peer,
                  @on_failed = nil, @on_fatal_error = nil,
                  @logger : Logger)
   end
@@ -28,14 +28,14 @@ class EMail::Sender
   def initialize(server_host : String, server_port : Int32 = EMail::DEFAULT_SMTP_PORT, *,
                  client_name : String = EMail::Client::DEFAULT_NAME, helo_domain : String? = nil,
                  on_failed : EMail::Client::OnFailedProc? = nil, on_fatal_error : EMail::Client::OnFatalErrorProc? = nil,
-                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : OpenSSL::SSL::VerifyMode? = nil,
+                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : OpenSSL::SSL::VerifyMode = :peer,
                  log_io : IO? = nil, log_progname : String? = nil,
                  log_formatter : Logger::Formatter? = nil, log_level : Logger::Severity? = nil)
     logger = EMail::Client.create_default_logger(log_io, log_progname, log_formatter, log_level)
     initialize(server_host, server_port,
       client_name: client_name, helo_domain: helo_domain,
       on_failed: on_failed, on_fatal_error: on_fatal_error, use_tls: use_tls,
-      auth: auth, openssl_verify_mode: openssl_verify_mode logger: logger)
+      auth: auth, openssl_verify_mode: openssl_verify_mode, logger: logger)
   end
 
   def enqueue(message : Message)

--- a/src/email/sender.cr
+++ b/src/email/sender.cr
@@ -10,6 +10,7 @@ class EMail::Sender
   @on_failed : EMail::Client::OnFailedProc?
   @on_fatal_error : EMail::Client::OnFatalErrorProc?
   @use_tls : Bool
+  @openssl_verify_mode : String?
   @auth : Tuple(String, String)?
   @logger : Logger
   @finished : Bool = false
@@ -19,22 +20,22 @@ class EMail::Sender
 
   def initialize(@server_host, @server_port = EMail::DEFAULT_SMTP_PORT, *,
                  @client_name = EMail::Client::DEFAULT_NAME, @helo_domain = nil,
+                 @use_tls = false, @auth = nil, @openssl_verify_mode = nil,
                  @on_failed = nil, @on_fatal_error = nil,
-                 @use_tls = false, @auth = nil,
                  @logger : Logger)
   end
 
   def initialize(server_host : String, server_port : Int32 = EMail::DEFAULT_SMTP_PORT, *,
                  client_name : String = EMail::Client::DEFAULT_NAME, helo_domain : String? = nil,
                  on_failed : EMail::Client::OnFailedProc? = nil, on_fatal_error : EMail::Client::OnFatalErrorProc? = nil,
-                 use_tls : Bool = false, auth : Tuple(String, String)? = nil,
+                 use_tls : Bool = false, auth : Tuple(String, String)? = nil, openssl_verify_mode : String? = nil,
                  log_io : IO? = nil, log_progname : String? = nil,
                  log_formatter : Logger::Formatter? = nil, log_level : Logger::Severity? = nil)
     logger = EMail::Client.create_default_logger(log_io, log_progname, log_formatter, log_level)
     initialize(server_host, server_port,
       client_name: client_name, helo_domain: helo_domain,
-      on_failed: on_failed, on_fatal_error: on_fatal_error,
-      use_tls: use_tls, auth: auth, logger: logger)
+      on_failed: on_failed, on_fatal_error: on_fatal_error, use_tls: use_tls,
+      auth: auth, openssl_verify_mode: openssl_verify_mode logger: logger)
   end
 
   def enqueue(message : Message)
@@ -86,8 +87,8 @@ class EMail::Sender
         client_name = @client_name + (@connection_count == 0 ? "" : "_#{@connection_count}")
         client = Client.new(@server_host, @server_port,
           client_name: client_name, helo_domain: @helo_domain,
-          on_failed: @on_failed, on_fatal_error: @on_fatal_error,
-          use_tls: @use_tls, auth: @auth, logger: @logger)
+          openssl_verify_mode: @openssl_verify_mode, auth: @auth, logger: @logger,
+          on_failed: @on_failed, on_fatal_error: @on_fatal_error, use_tls: @use_tls)
         @connection_count += 1
         client.start do
           sent_messages = 0


### PR DESCRIPTION
This adds ability to use `tls` with mail servers who use self-signed certificates. Otherwise you get this certificate verification error: 
```
SSL_connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed(OpenSSL::SSL::Error)
```
Updated ReadMe accordingly...