### PR TITLE
chore(shard.yml): update for crystal 1.0.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,9 @@
 name: email
-version: 0.6.2
+version: 0.6.3
 
 authors:
   - ʕ·ᴥ·ʔAKJ <arcage@denchu.org>
 
-crystal: 0.34.0
+crystal: ">= 0.34.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
currently to use this shard with crystal 1.0.0 you need to shards install --ignore-crystal-version